### PR TITLE
[Modify] Switch to MySql

### DIFF
--- a/Backend/prisma/schema.prisma
+++ b/Backend/prisma/schema.prisma
@@ -6,7 +6,7 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
+  provider = "mysql"
   url      = env("DATABASE_URL")
 }
 


### PR DESCRIPTION
This pull request modifies the database configuration in the Prisma schema file to switch the database provider from PostgreSQL to MySQL.

* [`Backend/prisma/schema.prisma`](diffhunk://#diff-c5204521fba08ada5e3186da11d0f82ac888a8675dccfee1c201ce95be5647ddL9-R9): Changed the `provider` field in the `datasource db` block from `"postgresql"` to `"mysql"`, reflecting a migration to a MySQL database.